### PR TITLE
Changed phase 2 auth

### DIFF
--- a/eduroam
+++ b/eduroam
@@ -26,5 +26,5 @@ WPAConfigSection=(
         'password=hash:<password hash>'
 # Password hashing ->  echo -n "<password>" | iconv -t utf16le | openssl md4
         'phase1="peaplabel=0"'
-        'phase2="auth=MSCHAPv2"'
+        'phase2="auth=MSCHAPV2"'
 )


### PR DESCRIPTION
Changed phase 2 auth as shown in the arch-wiki to prevent a bug due to the "v" being not a capital letter.
See: https://wiki.archlinux.org/index.php/Wpa_supplicant#Problems_with_eduroam_and_other_MSCHAPv2_connections